### PR TITLE
feat: :sparkles: add schema for extraction of contents

### DIFF
--- a/docs/guide/velite-schemas.md
+++ b/docs/guide/velite-schemas.md
@@ -315,6 +315,57 @@ code: s.raw()
 // => raw document body
 ```
 
+## `s.toc(options)`
+
+`string => Toc`
+
+parse input or document body as markdown content and return the table of contents.
+
+```ts
+toc: s.excerpt()
+// document body => table of contents
+```
+
+### Parameters
+
+#### **options**: toc options
+
+- type: `TocOptions`, See [Options](https://github.com/syntax-tree/mdast-util-toc?tab=readme-ov-file#options)
+
+### Types
+
+```ts
+interface TocEntry {
+  /**
+   * Title of the entry
+   */
+  title: string
+  /**
+   * URL that can be used to reach
+   * the content
+   */
+  url: string
+  /**
+   * Nested items
+   */
+  items: TocEntry[]
+}
+
+interface Toc {
+  /**
+   * Parsed entries
+   */
+  entries: TocEntry[]
+  /**
+   * Original AST tree that can be
+   * used for custom parsing or rendering
+   */
+  tree: Result
+}
+```
+
+Refer to [mdast-util-toc](https://github.com/syntax-tree/mdast-util-toc) for more information about `Result` and `Options`.
+
 ## Zod Primitive Types
 
 In addition, all Zod's built-in schemas can be used normally, such as:

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "hast-util-to-string": "^3.0.0",
     "mdast-util-from-markdown": "^2.0.0",
     "mdast-util-to-hast": "^13.1.0",
+    "mdast-util-toc": "^7.0.0",
     "micromatch": "^4.0.5",
     "prettier": "^3.2.5",
     "rehype-raw": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       mdast-util-to-hast:
         specifier: ^13.1.0
         version: 13.1.0
+      mdast-util-toc:
+        specifier: ^7.0.0
+        version: 7.0.0
       micromatch:
         specifier: ^4.0.5
         version: 4.0.5
@@ -1721,6 +1724,10 @@ packages:
     resolution: {integrity: sha512-Hy6UMpxhE3j1tLpl27exp1XqHD7n8chAiNPzWfz16LPZoMMoSc4dzLl6w9qijkEb/r5O1ozdu1CWGA2L83ZeZg==}
     dev: true
 
+  /@types/ungap__structured-clone@0.3.3:
+    resolution: {integrity: sha512-RNmhIPwoip6K/zZOv3ypksTAqaqLEXvlNSXKyrC93xMSOAHZCR7PifW6xKZCwkbbnbM9dwB9X56PPoNTlNwEqw==}
+    dev: true
+
   /@types/unist@2.0.10:
     resolution: {integrity: sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==}
     dev: true
@@ -3223,6 +3230,10 @@ packages:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  /github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+    dev: true
+
   /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -4139,6 +4150,18 @@ packages:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
     dependencies:
       '@types/mdast': 4.0.3
+    dev: true
+
+  /mdast-util-toc@7.0.0:
+    resolution: {integrity: sha512-C28UcSqjmnWuvgT8d97qpaItHKvySqVPAECUzqQ51xuMyNFFJwcFoKW77KoMjtXrclTidLQFDzLUmTmrshRweA==}
+    dependencies:
+      '@types/mdast': 4.0.3
+      '@types/ungap__structured-clone': 0.3.3
+      '@ungap/structured-clone': 1.2.0
+      github-slugger: 2.0.0
+      mdast-util-to-string: 4.0.0
+      unist-util-is: 6.0.0
+      unist-util-visit: 5.0.0
     dev: true
 
   /merge2@1.4.1:

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -7,6 +7,7 @@ import { mdx } from './mdx'
 import { metadata } from './metadata'
 import { raw } from './raw'
 import { slug } from './slug'
+import { toc } from './toc'
 import { unique } from './unique'
 import * as z from './zod'
 
@@ -31,9 +32,10 @@ export const s = {
   excerpt,
   markdown,
   mdx,
-  raw
+  raw,
+  toc
 }
 
 export { z } // keep z for backward compatibility
 
-export type { ZodType, Schema, infer } from './zod'
+export type { Schema, ZodType, infer } from './zod'

--- a/src/schemas/toc.ts
+++ b/src/schemas/toc.ts
@@ -1,6 +1,8 @@
+import { Link, List, Paragraph } from 'mdast'
 import { toc as extractToc, Options, Result } from 'mdast-util-toc'
 import remarkParse from 'remark-parse'
 import { unified } from 'unified'
+import { visit } from 'unist-util-visit'
 
 import { custom } from './zod'
 
@@ -11,9 +13,59 @@ import { custom } from './zod'
 export interface TocOptions extends Options {}
 
 /**
- * Table of contents result type
+ * Entry for a table of contents
+ * with title, url and items
  */
-export interface Toc extends Result {}
+export interface TocEntry {
+  title: string
+  url: string
+  items: TocEntry[]
+}
+
+/**
+ * Table of contents
+ * with parsed entries and
+ * original tree
+ */
+export interface Toc {
+  entries: TocEntry[]
+  tree: Result
+}
+
+function parseParagraph(node: Paragraph): Omit<TocEntry, 'items'> {
+  if (node.type !== 'paragraph') return { title: '', url: '' }
+  let extraction = { title: '', url: '' }
+
+  visit(node, 'link', (link: Link) => {
+    extraction.url = link.url
+  })
+
+  visit(node, ['text', 'emphasis', 'strong', 'inlineCode'], text => {
+    // @ts-ignore Doesn't care about test
+    extraction.title += text.value
+  })
+
+  return extraction
+}
+
+function parse(tree?: List): TocEntry[] {
+  if (!tree || tree?.type !== 'list') return []
+
+  const layer = tree.children.flatMap(node => node.children)
+  const entries = layer.flatMap((node, index) => {
+    if (node.type === 'paragraph')
+      return [
+        {
+          ...parseParagraph(node),
+          items: parse(layer[index + 1] as List) // Safe, next node can be either a list or a paragraph
+        }
+      ]
+
+    return []
+  })
+
+  return entries
+}
 
 export const toc = (options?: TocOptions) =>
   custom<string>().transform<Toc>(async (value, { meta: { file }, addIssue }) => {
@@ -25,7 +77,8 @@ export const toc = (options?: TocOptions) =>
       // extract ast tree from markdown/mdx content
       // TODO: understand if is possible to reuse tree from markdown/mdx schema
       const tree = await unified().use(remarkParse).parse({ value, path: file.path })
-      return extractToc(tree, options) // run toc extraction
+      const tocTree = extractToc(tree, options) // run toc extraction
+      return { tree: tocTree, entries: parse(tocTree.map) }
     } catch (err: any) {
       addIssue({ code: 'custom', message: err.message })
       return null as never

--- a/src/schemas/toc.ts
+++ b/src/schemas/toc.ts
@@ -1,0 +1,33 @@
+import { toc as extractToc, Options, Result } from 'mdast-util-toc'
+import remarkParse from 'remark-parse'
+import { unified } from 'unified'
+
+import { custom } from './zod'
+
+/**
+ * Options for table of contents
+ * extraction
+ */
+export interface TocOptions extends Options {}
+
+/**
+ * Table of contents result type
+ */
+export interface Toc extends Result {}
+
+export const toc = (options?: TocOptions) =>
+  custom<string>().transform<Toc>(async (value, { meta: { file }, addIssue }) => {
+    if (value == null && file.data.content != null) {
+      value = file.data.content
+    }
+
+    try {
+      // extract ast tree from markdown/mdx content
+      // TODO: understand if is possible to reuse tree from markdown/mdx schema
+      const tree = await unified().use(remarkParse).parse({ value, path: file.path })
+      return extractToc(tree, options) // run toc extraction
+    } catch (err: any) {
+      addIssue({ code: 'custom', message: err.message })
+      return null as never
+    }
+  })

--- a/src/schemas/toc.ts
+++ b/src/schemas/toc.ts
@@ -17,8 +17,18 @@ export interface TocOptions extends Options {}
  * with title, url and items
  */
 export interface TocEntry {
+  /**
+   * Title of the entry
+   */
   title: string
+  /**
+   * URL that can be used to reach
+   * the content
+   */
   url: string
+  /**
+   * Nested items
+   */
   items: TocEntry[]
 }
 
@@ -28,7 +38,14 @@ export interface TocEntry {
  * original tree
  */
 export interface Toc {
+  /**
+   * Parsed entries
+   */
   entries: TocEntry[]
+  /**
+   * Original AST tree that can be
+   * used for custom parsing or rendering
+   */
   tree: Result
 }
 


### PR DESCRIPTION
This pull request introduces a fresh Zod schema enabling the extraction of a table of contents directly from markdown/mdx.

The existing implementation generates a new tree based on the initial file input. A potential enhancement involves performing the extraction directly from the parsed tree obtained from either s.markdown() or s.mdx().