### PR TITLE
fix(docs): correct code example in `velite-schemas.md`

### DIFF
--- a/docs/guide/velite-schemas.md
+++ b/docs/guide/velite-schemas.md
@@ -322,7 +322,7 @@ code: s.raw()
 parse input or document body as markdown content and return the table of contents.
 
 ```ts
-toc: s.excerpt()
+toc: s.toc()
 // document body => table of contents
 ```
 


### PR DESCRIPTION
Replace `s.excerpt()` by `s.toc()` on [`s.toc(options)` example](s.toc(options))