### PR TITLE
Support extra options to config file esbuild

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 node_modules
 
 dist
+
+
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1709126324,
+        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1709237383,
+        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "Dev env for my blog";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        nodeVerion = pkgs.nodejs_20;
+      in
+      with pkgs; {
+        devShells = {
+          default = mkShell { buildInputs = [ nodeVerion ]; };
+        };
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       in
       with pkgs; {
         devShells = {
-          default = mkShell { buildInputs = [ nodeVerion ]; };
+          default = mkShell { buildInputs = [ nodeVerion nodePackages.pnpm ]; };
         };
       });
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import { build } from 'esbuild'
 import { name } from '../package.json'
 import { loaders } from './loaders'
 import { logger } from './logger'
+import * as z from './schemas/zod/'
 
 import type { Config, UserConfig } from './types'
 
@@ -39,12 +40,14 @@ const importFile = async (path: string) => {
   return mod.default ?? mod
 }
 
+const externalPackagesSchema = z.array(z.string())
+
 const loadExtraExternal = async (path: string) => {
   const externalStats = await stat(path)
   if (externalStats.isFile()) {
-    // TODO: validate its a json array of strings
     const res = await readFile(path, 'utf8')
-    return JSON.parse(res)
+    const json = JSON.parse(res)
+    return externalPackagesSchema.parseAsync(json)
   }
 
   return []


### PR DESCRIPTION
I added some logic to read in extra external packages to use when calling esbuild on the config file. They can be stored in a `velite.external.json` file next to the config file. 


The reason i added this option was from trying to integrate https://shiki.style/packages/twoslash. I may have been configuring things wrong (not very well versed in ESM) but adding that package to the external list helped me run velite without issue. (If i didnt include I got errors about unexpected requires of `fs`)



I also added a `flake.nix` to setup a dev shell for nix users. I can remove it if its too much noise