### PR TITLE
feat: `--strict` option

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -62,6 +62,13 @@ Whether to build in production mode. -->
 
 Log level.
 
+#### `options.strict`
+
+- Type: `boolean`
+- Default: `false`
+
+If true, throws an error and terminates the process if any schema validation fails. Otherwise, a warning is logged but the process does not terminate.
+
 ### Returns
 
 - Type: `Promise<Result>`, See [Result](#result).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -41,14 +41,15 @@ $ velite build [options]
 
 ### Options
 
-| Option                | Description                         | Default            |
-| --------------------- | ----------------------------------- | ------------------ |
-| `-c, --config <path>` | Use specified config file           | `velite.config.js` |
-| `--clean`             | Clean output directory before build | `false`            |
-| `--watch`             | Watch for changes and rebuild       | `false`            |
-| `--verbose`           | Print additional information        | `false`            |
-| `--silent`            | Silent mode (no output)             | `false`            |
-| `--debug`             | Output full error stack trace       | `false`            |
+| Option                | Description                                  | Default            |
+| --------------------- | -------------------------------------------- | ------------------ |
+| `-c, --config <path>` | Use specified config file                    | `velite.config.js` |
+| `--clean`             | Clean output directory before build          | `false`            |
+| `--watch`             | Watch for changes and rebuild                | `false`            |
+| `--verbose`           | Print additional information                 | `false`            |
+| `--silent`            | Silent mode (no output)                      | `false`            |
+| `--strict`            | Terminate process on schema validation error | `false`            |
+| `--debug`             | Output full error stack trace                | `false`            |
 
 ## `velite dev`
 
@@ -62,13 +63,14 @@ $ velite dev [options]
 
 ### Options
 
-| Option                | Description                         | Default            |
-| --------------------- | ----------------------------------- | ------------------ |
-| `-c, --config <path>` | Use specified config file           | `velite.config.js` |
-| `--clean`             | Clean output directory before build | `false`            |
-| `--verbose`           | Print additional information        | `false`            |
-| `--silent`            | Silent mode (no output)             | `false`            |
-| `--debug`             | Output full error stack trace       | `false`            |
+| Option                | Description                                  | Default            |
+| --------------------- | -------------------------------------------- | ------------------ |
+| `-c, --config <path>` | Use specified config file                    | `velite.config.js` |
+| `--clean`             | Clean output directory before build          | `false`            |
+| `--verbose`           | Print additional information                 | `false`            |
+| `--silent`            | Silent mode (no output)                      | `false`            |
+| `--strict`            | Terminate process on schema validation error | `false`            |
+| `--debug`             | Output full error stack trace                | `false`            |
 
 ## `velite init`
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,7 @@ const { values, positionals } = parse({
     watch: { type: 'boolean', default: false },
     verbose: { type: 'boolean', default: false },
     silent: { type: 'boolean', default: false },
+    strict: { type: 'boolean', short: 's', default: false },
     debug: { type: 'boolean', default: false },
     help: { type: 'boolean', short: 'h', default: false },
     version: { type: 'boolean', short: 'v', default: false }
@@ -49,6 +50,7 @@ Options:
   --watch              Watch for changes and rebuild
   --verbose            Print additional information
   --silent             Silent mode (no output)
+  --strict             Throw error and terminate process if any schema validation fails
   --debug              Output full error stack trace
   -h, --help           Display this message
   -v, --version        Display version number

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,13 +63,15 @@ const loadConfig = async (path: string): Promise<UserConfig> => {
   return mod.default ?? mod
 }
 
+export type ResolveConfigOptions = Pick<Config, 'strict'> & { clean?: boolean }
+
 /**
  * resolve config from user's project
  * @param path specific config file path (relative or absolute)
  * @param clean whether to clean output directories, for cli option
  * @returns resolved config object with default values
  */
-export const resolveConfig = async (path?: string, clean?: boolean): Promise<Config> => {
+export const resolveConfig = async (path?: string, opts: ResolveConfigOptions = {}): Promise<Config> => {
   const begin = performance.now()
 
   // prettier-ignore
@@ -104,8 +106,9 @@ export const resolveConfig = async (path?: string, clean?: boolean): Promise<Con
       base: output?.base ?? '/static/',
       name: output?.name ?? '[name]-[hash:8].[ext]',
       // ignore: output?.ignore ?? [],
-      clean: clean ?? output?.clean ?? false
+      clean: opts.clean ?? output?.clean ?? false
     },
-    loaders: [...customLoaders, ...loaders]
+    loaders: [...customLoaders, ...loaders],
+    strict: opts.strict ?? false
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -238,6 +238,12 @@ export interface UserConfig<T extends Collections = Collections> extends Partial
    */
   mdx?: MdxOptions
   /**
+   * If true, throws error and terminates process if any schema validation fails.
+   *
+   * @default false
+   */
+  strict?: boolean
+  /**
    * Data prepare hook, before write to file
    * @description
    * You can apply additional processing to the output data, such as modify them, add missing data, handle relationships, or write them to files.


### PR DESCRIPTION
## Overview

I was looking for the ability to terminate Velite with an error code if any schema validation fails. The use case I have in mind is for CI. For example
- someone creates a PR, they forget a mandatory top matter field
- we run Velite build on CI
- I'd like the Velite build will fail on CI, resulting in a failed CI check and preventing the PR from getting merged

This PR introduces a simple flag I named `--strict`. If true, the throw error and terminate the process on any schema validation error.

## Testing

Can this like so:
- edit `examples/basic/content/pages/about/index.mdx`: remove the `title` field
- edit `examples/basic/package.json`: change the build command to `velite build --strict`. 

run the build command for `examples/basic`, it should fail. 

<img width="739" alt="image" src="https://github.com/zce/velite/assets/26701004/c37d9927-30ff-4780-b5cb-db56b1dee743">
