### PR TITLE
fix: class File to VeliteFile

### DIFF
--- a/docs/guide/custom-schema.md
+++ b/docs/guide/custom-schema.md
@@ -96,4 +96,4 @@ export const path = defineSchema(() =>
 
 ### Reference
 
-the type of `meta` is `ZodMeta`, which extends [`VeliteFile`](../reference/types.md#VeliteFile).
+the type of `meta` is `ZodMeta`, which extends [`VeliteFile`](../reference/types.md#velitefile).

--- a/docs/guide/define-collections.md
+++ b/docs/guide/define-collections.md
@@ -172,7 +172,7 @@ const posts = defineCollection({
 })
 ```
 
-the type of `meta` is `ZodMeta`, which extends [`VeliteFile`](../reference/types.md#VeliteFile). for more information, see [Custom Schema](custom-schema.md).
+the type of `meta` is `ZodMeta`, which extends [`VeliteFile`](../reference/types.md#velitefile). for more information, see [Custom Schema](custom-schema.md).
 
 ## Content Body
 

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -66,9 +66,9 @@ interface Loader {
 ## VeliteFile
 
 ```ts
-interface ZodMeta extends File {}
+interface ZodMeta extends VeliteFile {}
 
-class File extends VFile {
+class VeliteFile extends VFile {
   /**
    * Get parsed records from file
    */
@@ -99,14 +99,14 @@ class File extends VFile {
    * @param path file path
    * @returns resolved meta object if exists
    */
-  static get(path: string): File | undefined
+  static get(path: string): VeliteFile | undefined
 
   /**
    * Create meta object from file path
    * @param options meta options
    * @returns resolved meta object
    */
-  static async create({ path, config }: { path: string; config: Config }): Promise<File>
+  static async create({ path, config }: { path: string; config: Config }): Promise<VeliteFile>
 }
 ```
 

--- a/src/build.ts
+++ b/src/build.ts
@@ -6,7 +6,7 @@ import { reporter } from 'vfile-reporter'
 
 import { assets } from './assets'
 import { resolveConfig } from './config'
-import { File } from './file'
+import { VeliteFile } from './file'
 import { logger } from './logger'
 import { outputAssets, outputData, outputEntry } from './output'
 
@@ -15,7 +15,7 @@ import type { Schema } from './schemas'
 import type { Config } from './types'
 
 // cache resolved result for rebuild
-const resolved = new Map<string, File[]>()
+const resolved = new Map<string, VeliteFile[]>()
 
 /**
  * Load file and parse data with given schema
@@ -24,16 +24,16 @@ const resolved = new Map<string, File[]>()
  * @param schema data schema
  * @param changed changed file path (relative to content root)
  */
-const load = async (config: Config, path: string, schema: Schema, changed?: string): Promise<File> => {
+const load = async (config: Config, path: string, schema: Schema, changed?: string): Promise<VeliteFile> => {
   path = normalize(path)
 
   if (changed != null && path !== changed) {
-    const exists = File.get(path)
+    const exists = VeliteFile.get(path)
     // skip file if changed file not match
     if (exists) return exists
   }
 
-  const meta = await File.create({ path, config })
+  const meta = await VeliteFile.create({ path, config })
 
   // may be one or more records in one file, such as yaml array or json array
   const isArr = Array.isArray(meta.records)
@@ -70,7 +70,7 @@ const resolve = async (config: Config, changed?: string): Promise<Record<string,
   logger.log(`resolving collections from '${root}'`)
 
   const entries = await Promise.all(
-    Object.entries(collections).map(async ([name, { pattern, schema }]): Promise<[string, File[]]> => {
+    Object.entries(collections).map(async ([name, { pattern, schema }]): Promise<[string, VeliteFile[]]> => {
       if (changed != null && !micromatch.contains(changed, pattern) && resolved.has(name)) {
         // skip collection if changed file not match
         logger.log(`skipped resolve '${name}', using previous resolved`)

--- a/src/file.ts
+++ b/src/file.ts
@@ -10,9 +10,9 @@ import type { Root } from 'mdast'
 import type { Config } from './types'
 
 // cache loaded files for rebuild
-const loaded = new Map<string, File>()
+const loaded = new Map<string, VeliteFile>()
 
-export class File extends VFile {
+export class VeliteFile extends VFile {
   config: Config
   private _mdast: Root | undefined
   private _hast: Nodes | undefined
@@ -72,7 +72,7 @@ export class File extends VFile {
    * @param path file path
    * @returns resolved meta object if exists
    */
-  static get(path: string): File | undefined {
+  static get(path: string): VeliteFile | undefined {
     return loaded.get(path)
   }
 
@@ -81,8 +81,8 @@ export class File extends VFile {
    * @param options meta options
    * @returns resolved meta object
    */
-  static async create({ path, config }: { path: string; config: Config }): Promise<File> {
-    const meta = new File({ path, config })
+  static async create({ path, config }: { path: string; config: Config }): Promise<VeliteFile> {
+    const meta = new VeliteFile({ path, config })
     const loader = config.loaders.find(loader => loader.test.test(path))
     if (loader == null) return meta.fail(`no loader found for '${path}'`)
     meta.value = await readFile(path)
@@ -94,5 +94,5 @@ export class File extends VFile {
 }
 
 declare module './schemas' {
-  interface ZodMeta extends File {}
+  interface ZodMeta extends VeliteFile {}
 }


### PR DESCRIPTION
While reviewing the `VeliteFile` section at https://velite.js.org/reference/types, I noticed that the class is named `File`, which is already defined in Node.js. Additionally, the document title is `VeliteFile`, but the class name is `File`, which seems inconsistent. Therefore, I have renamed the `File` class to `VeliteFile` and updated the associated files accordingly. I have also made these changes in the documentation.

In documents like [/guide/custom-schema](https://velite.js.org/guide/custom-schema), the links that should point to the `VeliteFile` reference were not functioning correctly. This was due to the links pointing to `#VeliteFile` instead of `#velitefile`. I have corrected these links in the documentation.