### PR TITLE
Update next.config.js code to start Velite with next dev and next bui…

### DIFF
--- a/docs/guide/with-nextjs.md
+++ b/docs/guide/with-nextjs.md
@@ -15,7 +15,7 @@ in your `next.config.js`:
 ```js [CommonJS]
 /** @type {import('next').NextConfig} */
 module.exports = {
-  // other next config here...
+  // othor next config here...
   webpack: config => {
     config.plugins.push(new VeliteWebpackPlugin())
     return config
@@ -24,20 +24,15 @@ module.exports = {
 
 class VeliteWebpackPlugin {
   static started = false
-  constructor(/** @type {import('velite').Options} */ options = {}) {
-    this.options = options
-  }
   apply(/** @type {import('webpack').Compiler} */ compiler) {
-    // executed three times in nextjs !!!
+    // executed three times in nextjs
     // twice for the server (nodejs / edge runtime) and once for the client
     compiler.hooks.beforeCompile.tapPromise('VeliteWebpackPlugin', async () => {
       if (VeliteWebpackPlugin.started) return
       VeliteWebpackPlugin.started = true
       const dev = compiler.options.mode === 'development'
-      this.options.watch = this.options.watch ?? dev
-      this.options.clean = this.options.clean ?? !dev
       const { build } = await import('velite')
-      await build(this.options) // start velite
+      await build({ watch: dev, clean: !dev })
     })
   }
 }
@@ -57,19 +52,14 @@ export default {
 
 class VeliteWebpackPlugin {
   static started = false
-  constructor(/** @type {import('velite').Options} */ options = {}) {
-    this.options = options
-  }
   apply(/** @type {import('webpack').Compiler} */ compiler) {
-    // executed three times in nextjs !!!
+    // executed three times in nextjs
     // twice for the server (nodejs / edge runtime) and once for the client
     compiler.hooks.beforeCompile.tapPromise('VeliteWebpackPlugin', async () => {
       if (VeliteWebpackPlugin.started) return
       VeliteWebpackPlugin.started = true
       const dev = compiler.options.mode === 'development'
-      this.options.watch = this.options.watch ?? dev
-      this.options.clean = this.options.clean ?? !dev
-      await build(this.options) // start velite
+      await build({ watch: dev, clean: !dev })
     })
   }
 }


### PR DESCRIPTION
The code currently in the documentation to integrate Velite into Next.JS with the Plugin isn't working. The Next.JS example in the repository is working, and this updates the documentation with the code from the example in the repository.