### PR TITLE
feat: new hook context

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -269,12 +269,29 @@ More options, see [MDX Compile Options](https://mdxjs.com/packages/mdx/#compileo
 
 ## `prepare`
 
-- Type: `(result: Result<Collections>) => Promisable<void | false>`
+- Type: `(data: Result<Collections>, context: Context) => Promisable<void | false>`
 
 Data prepare hook, executed before write to file. You can apply additional processing to the output data, such as modify them, add missing data, handle relationships, or write them to files. return false to prevent the default output to a file if you wanted.
 
+```js
+export default defineConfig({
+  collections: { posts, tags },
+  prepare: (data, context) => {
+    // modify data
+    data.posts.push({ ... })
+    data.tags.push({ ... })
+
+    // context
+    const { config } = context
+    // config is resolved from `velite.config.js` with default values
+
+    // return false to prevent the default output to a file
+  }
+})
+```
+
 ## `complete`
 
-- Type: `(result: Result<Collections>) => Promisable<void>`
+- Type: `(data: Result<Collections>, context: Context) => Promisable<void>`
 
 Build success hook, executed after the build is complete. You can do anything after the build is complete, such as print some tips or deploy the output files.

--- a/src/build.ts
+++ b/src/build.ts
@@ -134,11 +134,13 @@ const resolve = async (config: Config, changed?: string): Promise<Record<string,
     })
   )
 
+  const context = { config }
+
   let shouldOutput = true
   // apply prepare hook
   if (typeof prepare === 'function') {
     const begin = performance.now()
-    shouldOutput = (await prepare(result)) ?? true
+    shouldOutput = (await prepare(result, context)) ?? true
     logger.log(`executed 'prepare' callback got ${shouldOutput}`, begin)
   }
 
@@ -155,7 +157,7 @@ const resolve = async (config: Config, changed?: string): Promise<Record<string,
   // call complete hook
   if (typeof complete === 'function') {
     const begin = performance.now()
-    await complete(result)
+    await complete(result, context)
     logger.log(`executed 'complete' callback`, begin)
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -199,6 +199,13 @@ export type CollectionType<T extends Collections, P extends keyof T> = T[P]['sin
 export type Result<T extends Collections> = { [P in keyof T]: CollectionType<T, P> }
 
 /**
+ * Hook context
+ */
+export type Context = {
+  config: Config
+}
+
+/**
  * This interface for plugins extra user config
  * @example
  * declare module 'velite' {
@@ -252,14 +259,14 @@ export interface UserConfig<T extends Collections = Collections> extends Partial
    * return false to prevent the default output to a file if you wanted
    * @param data loaded data
    */
-  prepare?: (data: Result<T>) => Promisable<void | false>
+  prepare?: (data: Result<T>, context: Context) => Promisable<void | false>
   /**
    * Build success hook
    * @description
    * You can do anything after the build is complete, such as print some tips or deploy the output files.
    * @param data loaded data
    */
-  complete?: (data: Result<T>) => Promisable<void>
+  complete?: (data: Result<T>, context: Context) => Promisable<void>
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -202,6 +202,9 @@ export type Result<T extends Collections> = { [P in keyof T]: CollectionType<T, 
  * Hook context
  */
 export type Context = {
+  /**
+   * Resolved config
+   */
   config: Config
 }
 


### PR DESCRIPTION
## `prepare`

- Type: `(data: Result<Collections>, context: Context) => Promisable<void | false>`

Data prepare hook, executed before write to file. You can apply additional processing to the output data, such as modify them, add missing data, handle relationships, or write them to files. return false to prevent the default output to a file if you wanted.

```js
export default defineConfig({
  collections: { posts, tags },
  prepare: (data, context) => {
    // modify data
    data.posts.push({ ... })
    data.tags.push({ ... })

    // context
    const { config } = context
    // config is resolved from `velite.config.js` with default values

    // return false to prevent the default output to a file
  }
})
```

## `complete`

- Type: `(data: Result<Collections>, context: Context) => Promisable<void>`

Build success hook, executed after the build is complete. You can do anything after the build is complete, such as print some tips or deploy the output files.


close: #161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated configuration documentation to include the new `context` parameter for `prepare` and `complete` functions.

- **New Features**
  - Introduced a `context` parameter to the `prepare` and `complete` functions, allowing more context-aware operations within the build process.

- **Refactor**
  - Modified internal functions to accept and utilize the new `context` parameter for enhanced configurability and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->