### PR TITLE
fix(docs): show wrong image in light theme

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -20,7 +20,9 @@
   overflow: hidden;
 }
 
-.light .vp-doc img[src$='#dark'] {
+html:not(.dark) .vp-doc img[src$='#dark']{
+  display: none;
+}
   display: none;
 }
 


### PR DESCRIPTION
Hi reviewer,

I see the issue, both images are showing on light theme mode. I changed the CSS to show specific images in dark and light modes at: https://velite.js.org/guide/introduction


**Previous Behaviour:**

![image](https://github.com/user-attachments/assets/1bdd5bba-ae15-41e8-8adc-0c75d33c0362)

**After:**

![image](https://github.com/user-attachments/assets/0b3219a6-ef55-4a55-b484-09f59e42290f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced documentation theme to conditionally hide images intended for dark mode when viewed in light mode.
  
- **Bug Fixes**
	- Clarified CSS rules for improved visibility of images based on the current theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->