### PR TITLE
feat: add `preserveConfigExtension` option

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -101,6 +101,12 @@ interface Options {
    * @default 'info'
    */
   logLevel?: LogLevel
+  /**
+   * If true, preserves the extension of the `velite.config.[ts|js]` file in the output `index.d.ts` file.
+   * Useful if `"moduleResolution": "NodeNext"` where extension-less files aren't supported.
+   * @default false
+   */
+  preserveConfigExtension?: boolean
 }
 ```
 

--- a/src/build.ts
+++ b/src/build.ts
@@ -1,7 +1,7 @@
-import { mkdir, rm } from 'node:fs/promises'
-import { join, normalize } from 'node:path'
 import glob from 'fast-glob'
 import micromatch from 'micromatch'
+import { mkdir, rm } from 'node:fs/promises'
+import { join, normalize } from 'node:path'
 import { reporter } from 'vfile-reporter'
 
 import { assets } from './assets'
@@ -241,6 +241,12 @@ export interface Options {
    * @default false
    */
   strict?: boolean
+  /**
+   * If true, preserves the extension of the `velite.config` file in the output `index.d.ts` file.
+   * Useful if `"moduleResolution": "NodeNext"` where extension-less files aren't supported.
+   * @default false
+   */
+  preserveConfigExtension?: boolean
 }
 
 /**
@@ -248,7 +254,7 @@ export interface Options {
  * @param options build options
  */
 export const build = async (options: Options = {}): Promise<Record<string, unknown>> => {
-  const { config: configFile, clean, logLevel, strict } = options
+  const { config: configFile, clean, logLevel, strict, preserveConfigExtension = false } = options
 
   logLevel != null && logger.set(logLevel)
 
@@ -272,7 +278,7 @@ export const build = async (options: Options = {}): Promise<Record<string, unkno
   await mkdir(output.data, { recursive: true })
   await mkdir(output.assets, { recursive: true })
 
-  await outputEntry(output.data, configPath, collections)
+  await outputEntry(output.data, configPath, collections, preserveConfigExtension)
 
   logger.log('initialized', begin)
 

--- a/src/output.ts
+++ b/src/output.ts
@@ -28,14 +28,18 @@ export const emit = async (path: string, content: string, log?: string): Promise
  * @param dest output destination directory
  * @param configPath resolved config file path
  * @param collections collection options
+ * @param preserveConfigExtension if true, preserves the extension of the `velite.config` file in the output `index.d.ts` file.
  */
-export const outputEntry = async (dest: string, configPath: string, collections: Collections): Promise<void> => {
+export const outputEntry = async (dest: string, configPath: string, collections: Collections, preserveConfigExtension: boolean = false): Promise<void> => {
   const begin = performance.now()
 
   // generate entry according to `config.collections`
-  const configModPath = relative(dest, configPath)
+  let configModPath = relative(dest, configPath)
     .replace(/\\/g, '/') // replace windows path separator
-    .replace(/\.[mc]?[jt]s$/i, '') // remove extension
+
+  if (!preserveConfigExtension) {
+	configModPath = configModPath.replace(/\.[mc]?[jt]s$/i, '') // remove extension
+  }
 
   const entry: string[] = []
   const dts: string[] = [`import config from '${configModPath}'\n`]


### PR DESCRIPTION
Closes #231

## Summary by Sourcery

Add a new `preserveConfigExtension` option to the build process, which allows users to preserve the file extension of the `velite.config` file in the output. This is particularly useful for environments using `"moduleResolution": "NodeNext"` where extension-less files are not supported. Update the API documentation to reflect this new option.

New Features:
- Introduce the `preserveConfigExtension` option to the build process, allowing the preservation of the `velite.config` file extension in the output `index.d.ts` file.

Documentation:
- Update the API documentation to include the new `preserveConfigExtension` option, explaining its purpose and default value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new optional parameter, `preserveConfigExtension`, in the API reference for the `build` function, allowing users to retain the extension of the `velite.config` file in the output.
  
- **Documentation**
	- Updated API documentation to include details about the new `preserveConfigExtension` parameter and its default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->