### PR TITLE
feat: support format config

### DIFF
--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -239,6 +239,8 @@ console.log(posts) // => [{ title: 'Hello world', slug: 'hello-world', ... }, ..
 
 Velite is **Framework Agnostic**, you can use it output with any framework or library you like.
 
+From version `0.2.0`, Velite will output the entry file in the format you specified in the config. so you can choose the format you like.
+
 :::
 
 For more information about using collections, see [Using Collections](using-collections.md).

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -127,6 +127,13 @@ The extensions blacklist of the assets, such as `['.md', '.yml']`, will be ignor
 
 Whether to clean the output directories before build.
 
+### `output.format`
+
+- Type: `'esm' | 'cjs'`
+- Default: `'esm'`
+
+The output format of the entry file.
+
 ## `collections`
 
 - Type: `{ [name: string]: Collection }`

--- a/src/build.ts
+++ b/src/build.ts
@@ -273,7 +273,7 @@ export const build = async (options: Options = {}): Promise<Record<string, unkno
   await mkdir(output.data, { recursive: true })
   await mkdir(output.assets, { recursive: true })
 
-  await outputEntry(output.data, configPath, collections)
+  await outputEntry(output.data, output.format, configPath, collections)
 
   logger.log('initialized', begin)
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -108,7 +108,8 @@ export const resolveConfig = async (path?: string, options: { strict?: boolean; 
       assets: resolve(cwd, loadedConfig.output?.assets ?? 'public/static'),
       base: loadedConfig.output?.base ?? '/static/',
       name: loadedConfig.output?.name ?? '[name]-[hash:8].[ext]',
-      clean: options.clean ?? loadedConfig.output?.clean ?? false
+      clean: options.clean ?? loadedConfig.output?.clean ?? false,
+      format: loadedConfig.output?.format ?? 'esm'
     },
     loaders: [...(loadedConfig.loaders ?? []), ...loaders],
     strict: options.strict ?? loadedConfig.strict ?? false

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,6 +141,11 @@ export interface Output {
    * @default false
    */
   clean: boolean
+  /**
+   * Output entry file format
+   * @default 'esm'
+   */
+  format: 'esm' | 'cjs'
 }
 
 /**

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -12,7 +12,7 @@ test('standalone fixtures', async t => {
   equal(entry.length, 288, 'entry output length should be 288')
 
   const dts = await readFile('examples/basic/.velite/index.d.ts', 'utf8')
-  equal(dts.length, 628, 'dts output length should be 628')
+  equal(dts.length, 636, 'dts output length should be 636')
 
   const options = await readFile('examples/basic/.velite/options.json', 'utf8')
   equal(options.length, 1121, 'options output length should be 1121')
@@ -20,14 +20,14 @@ test('standalone fixtures', async t => {
   const categories = await readFile('examples/basic/.velite/categories.json', 'utf8')
   equal(categories.length, 880, 'categories output length should be 880')
 
-  const tags = await readFile('examples/basic/.velite/tags.json', 'utf8')
-  equal(tags.length, 315, 'tags output length should be 315')
-
   const pages = await readFile('examples/basic/.velite/pages.json', 'utf8')
   equal(pages.length, 6182, 'pages output length should be 6182')
 
   const posts = await readFile('examples/basic/.velite/posts.json', 'utf8')
   equal(posts.length, 14165, 'posts output length should be 14165')
+
+  const tags = await readFile('examples/basic/.velite/tags.json', 'utf8')
+  equal(tags.length, 315, 'tags output length should be 315')
 
   await rm('examples/basic/.velite', { recursive: true, force: true })
 })

--- a/test/nextjs.ts
+++ b/test/nextjs.ts
@@ -11,22 +11,22 @@ test('integration with nextjs fixtures', async t => {
   equal(entry.length, 288, 'entry output length should be 288')
 
   const dts = await readFile('examples/nextjs/.velite/index.d.ts', 'utf8')
-  equal(dts.length, 628, 'dts output length should be 628')
+  equal(dts.length, 636, 'dts output length should be 636')
 
   const options = await readFile('examples/nextjs/.velite/options.json', 'utf8')
-  equal(options.length, 1121, 'options output length should be 1121')
+  equal(options.length, 775, 'options output length should be 775')
 
   const categories = await readFile('examples/nextjs/.velite/categories.json', 'utf8')
-  equal(categories.length, 880, 'categories output length should be 880')
-
-  const tags = await readFile('examples/nextjs/.velite/tags.json', 'utf8')
-  equal(tags.length, 315, 'tags output length should be 315')
+  equal(categories.length, 649, 'categories output length should be 649')
 
   const pages = await readFile('examples/nextjs/.velite/pages.json', 'utf8')
-  equal(pages.length, 5003, 'pages output length should be 5003')
+  equal(pages.length, 4942, 'pages output length should be 4942')
 
   const posts = await readFile('examples/nextjs/.velite/posts.json', 'utf8')
-  equal(posts.length, 20171, 'posts output length should be 20171')
+  equal(posts.length, 17991, 'posts output length should be 17991')
+
+  const tags = await readFile('examples/nextjs/.velite/tags.json', 'utf8')
+  equal(tags.length, 212, 'tags output length should be 212')
 
   await rm('examples/nextjs/.velite', { recursive: true, force: true })
 })


### PR DESCRIPTION
## What's Changed

- Add new `format: 'esm' | 'cjs'` config
- Preserve Velite config file extension in output `.velite/index.d.ts`
- Stop JSON formatting in production env

## Related Issues

closes #221 #231 #232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `format` parameter for output flexibility during the build process, supporting both ES module and CommonJS formats.
	- Enhanced quick start guide with detailed installation, configuration, and usage instructions, including new sections on content files and watch mode functionality.

- **Bug Fixes**
	- Updated test cases to reflect changes in expected output lengths for various files, ensuring accuracy in output validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->