### PR TITLE
fix: rename import velite config to avoid naming conflicts

### DIFF
--- a/docs/guide/using-collections.md
+++ b/docs/guide/using-collections.md
@@ -34,9 +34,9 @@ export { default as others } from './others.json'
 ```
 
 ```js [index.d.ts]
-import config from '../velite.config'
+import type __vc from '../velite.config.js'
 
-type Collections = typeof config.collections
+type Collections = typeof __vc.collections
 
 export type Post = Collections['posts']['schema']['_output']
 export declare const posts: Post[]

--- a/src/output.ts
+++ b/src/output.ts
@@ -37,8 +37,8 @@ export const outputEntry = async (dest: string, format: Output['format'], config
   const configModPath = relative(dest, configPath).replace(/\\/g, '/')
 
   const entry: string[] = []
-  const dts: string[] = [`import type config from '${configModPath}'\n`]
-  dts.push('type Collections = typeof config.collections\n')
+  const dts: string[] = [`import type __vc from '${configModPath}'\n`]
+  dts.push('type Collections = typeof __vc.collections\n')
 
   Object.entries(collections).map(([name, collection]) => {
     if (format === 'cjs') {

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -12,7 +12,7 @@ test('standalone fixtures', async t => {
   equal(entry.length, 288, 'entry output length should be 288')
 
   const dts = await readFile('examples/basic/.velite/index.d.ts', 'utf8')
-  equal(dts.length, 636, 'dts output length should be 636')
+  equal(dts.length, 632, 'dts output length should be 632')
 
   const options = await readFile('examples/basic/.velite/options.json', 'utf8')
   equal(options.length, 1121, 'options output length should be 1121')

--- a/test/nextjs.ts
+++ b/test/nextjs.ts
@@ -11,7 +11,7 @@ test('integration with nextjs fixtures', async t => {
   equal(entry.length, 288, 'entry output length should be 288')
 
   const dts = await readFile('examples/nextjs/.velite/index.d.ts', 'utf8')
-  equal(dts.length, 636, 'dts output length should be 636')
+  equal(dts.length, 632, 'dts output length should be 632')
 
   const options = await readFile('examples/nextjs/.velite/options.json', 'utf8')
   equal(options.length, 775, 'options output length should be 775')


### PR DESCRIPTION
fix #248

## Summary by Sourcery

Rename the import of the velite config to '__vc' to avoid naming conflicts and update related test assertions.

Bug Fixes:
- Resolve naming conflicts by renaming the import of the velite config to '__vc'.

Tests:
- Update test assertions to reflect the new length of the 'dts' output after renaming the import.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the expected length of the TypeScript definition file output in tests, from 636 to 632, ensuring accurate validation of generated files.

- **Chores**
	- Updated type references in the output generation process to improve clarity and maintainability without altering existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->