### PR TITLE
fix duplication of images in dark mode

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -20,9 +20,11 @@
   overflow: hidden;
 }
 
-html:not(.dark) .vp-doc img[src$='#dark']{
+html:not(.dark) .vp-doc img[src$='#dark'] {
   display: none;
 }
+
+.light .vp-doc img[src$='#dark'] {
   display: none;
 }
 

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -24,10 +24,6 @@ html:not(.dark) .vp-doc img[src$='#dark'] {
   display: none;
 }
 
-.light .vp-doc img[src$='#dark'] {
-  display: none;
-}
-
 .dark .vp-doc img[src$='#light'] {
   display: none;
 }


### PR DESCRIPTION
Fix duplication of images in dark mode in https://velite.js.org/guide/introduction . The current CSS syntax is incorrect.

<img width="800" alt="" src="https://github.com/user-attachments/assets/6fa3207d-f787-4e18-b909-c0ff7c3983d4">

## Summary by Sourcery

Bug Fixes:
- Correct CSS syntax to prevent duplication of images in dark mode by ensuring images with '#dark' in their source are hidden in light mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced image visibility control based on selected themes (light/dark).
	- Defined specific brand colors for both light and dark themes.

- **Bug Fixes**
	- Improved handling of images to ensure correct display according to the active theme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->