### PR TITLE
Assign minimal value for blurHeight

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -70,7 +70,7 @@ export const getImageMetadata = async (buffer: Buffer): Promise<Omit<Image, 'src
   if (width == null || height == null) return
   const aspectRatio = width / height
   const blurWidth = 8
-  const blurHeight = Math.round(blurWidth / aspectRatio)
+  const blurHeight = Math.min(1, Math.round(blurWidth / aspectRatio))
   const blurImage = await img.resize(blurWidth, blurHeight).webp({ quality: 1 }).toBuffer()
   const blurDataURL = `data:image/webp;base64,${blurImage.toString('base64')}`
   return { height, width, blurDataURL, blurWidth, blurHeight }


### PR DESCRIPTION
Fixes #272 by assigning minimal blurHeight value to 1 (as far I can tell, minimal value for sharp), that way weird aspect ratios will work.