### PR TITLE
docs: modifying typos in guide document

### DIFF
--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -111,7 +111,7 @@ Velite is framework agnostic, and out of the box support for React, Vue, Svelte,
 - image processing by [Sharp](https://sharp.pixelplumbing.com)
 - file watching by [Chokidar](https://github.com/paulmillr/chokidar)
 
-### Fast Rebuid
+### Fast Rebuild
 
 More then **1000** documents with **2000** assets, less then **8s** for cold start, less then **60ms** for hot rebuild.
 

--- a/docs/guide/using-mdx.md
+++ b/docs/guide/using-mdx.md
@@ -167,7 +167,7 @@ import { Callout } from '../components/callout'
 
 :::
 
-If Velite uses a bundler to comiple your MDX, the `Callout` component will be bundled into each MDX file, which will cause a lot of redundancy in the output code.
+If Velite uses a bundler to compile your MDX, the `Callout` component will be bundled into each MDX file, which will cause a lot of redundancy in the output code.
 
 Instead, simply use whatever components you want in your MDX files without a import.
 


### PR DESCRIPTION
## What's Changed
- Correct typos in the file `docs/guide/using-mdx.md` (`comiple` -> `compile`)
- Corrent typos in the file `docs/guide/introduction.md` (`Rebuid` -> `Rebuild`)

### before

```md
If Velite uses a bundler to comiple your MDX, the `Callout` component will be bundled into each MDX file, which will cause a lot of redundancy in the output code.
```

```md
### Fast Rebuid
```

### after

```md
If Velite uses a bundler to compile your MDX, the `Callout` component will be bundled into each MDX file, which will cause a lot of redundancy in the output code
```

```md
### Fast Rebuild
```

Hello, I found a typo while reading the official document.
It’s a minor correction involving wording. The changes are purely textual and do not affect the technical content, structure, or functionality of the document. However, readers may find it distracting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Fixed a minor typo in the MDX usage guide, correcting "comiple" to "compile" for improved clarity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->