### PR TITLE
fix#315: set main field in package.json to allow direct ESM import

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "MIT",
   "author": "zce <w@zce.me> (https://zce.me)",
   "type": "module",
+  "main": "./dist/index.js",
   "exports": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": "./bin/velite.js",


### PR DESCRIPTION
Fixes https://github.com/zce/velite/issues/315

### Problem

When `velite` is bundled or imported dynamically (e.g. via `import()` in a tool's config loader), Node.js attempts to resolve its main entrypoint. Since `package.json` is missing a `"main"` field, this leads to resolution failures.

Without a "main" field, consumers using ESM imports (e.g. `import 'velite'`) in environments like Vercel or bundled configs encounter errors such as:

  Cannot find module 'node_modules/velite/dist/index.js' imported from ...

This is especially problematic in environments like Vercel, where strict resolution rules apply and tools like `esbuild` generate dynamic imports pointing to velite's output file.

---

### Solution

This PR adds:

```json
"main": "dist/index.js"
```

Adding the "main" field ensures consistent resolution behavior in Node.js and bundlers, avoiding brittle paths and import failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added a "main" entry point in the package configuration for improved compatibility with various consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->