### PR TITLE
fix: make ZodMeta extend VeliteFile as documented

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -15,10 +15,6 @@ import type { LogLevel } from './logger'
 import type { Schema, ZodMeta } from './schemas'
 import type { Config } from './types'
 
-declare module './schemas' {
-  interface ZodMeta extends VeliteFile {}
-}
-
 // cache resolved result for rebuild
 const resolved = new Map<string, VeliteFile[]>()
 

--- a/src/schemas/zod/helpers/parseUtil.ts
+++ b/src/schemas/zod/helpers/parseUtil.ts
@@ -1,3 +1,4 @@
+import { VeliteFile } from '../../../file'
 import { getErrorMap } from '../errors'
 import defaultErrorMap from '../locales/en'
 
@@ -36,9 +37,7 @@ export const makeIssue = (params: { data: any; path: (string | number)[]; errorM
   }
 }
 
-export interface ZodMeta {
-  [key: string | number | symbol]: unknown
-}
+export interface ZodMeta extends VeliteFile {}
 
 export type ParseParams = {
   path: (string | number)[]


### PR DESCRIPTION
fixed #348 

Make ZodMeta extend VeliteFile directly instead of using module augmentation