### PR TITLE
feat: add configurable blur options to image schema

### DIFF
--- a/docs/guide/velite-schemas.md
+++ b/docs/guide/velite-schemas.md
@@ -155,6 +155,21 @@ root path for absolute path, if provided, the value will be processed as an abso
 - type: `string`
 - default: `undefined`
 
+##### **options.blur**:
+
+blur placeholder options, used to customize the generated `blurDataURL`.
+
+- type: `{ width?: number; height?: number; quality?: number }`
+- default: `undefined`
+
+```ts
+avatar: s.image({ blur: { width: 16, quality: 30 } })
+```
+
+- `blur.width`: blur image width. default: `8`
+- `blur.height`: blur image height. default: derived from the image aspect ratio
+- `blur.quality`: webp quality of the blur image (1-100). default: `1`
+
 ### Types
 
 ```ts

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -38,6 +38,27 @@ export interface Image {
   blurHeight: number
 }
 
+/**
+ * Blur placeholder options
+ */
+export interface BlurOptions {
+  /**
+   * blur image width
+   * @default 8
+   */
+  width?: number
+  /**
+   * blur image height
+   * @default derived from aspect ratio
+   */
+  height?: number
+  /**
+   * webp quality of the blur image (1-100)
+   * @default 1
+   */
+  quality?: number
+}
+
 export const assets = new Map<string, string>()
 
 // https://github.com/sindresorhus/is-absolute-url/blob/main/index.js
@@ -63,15 +84,16 @@ export const isRelativePath = (url: string): boolean => {
  * @param buffer image buffer
  * @returns image object with blurDataURL
  */
-export const getImageMetadata = async (buffer: Buffer): Promise<Omit<Image, 'src'> | undefined> => {
+export const getImageMetadata = async (buffer: Buffer, blurOptions: BlurOptions = {}): Promise<Omit<Image, 'src'> | undefined> => {
   const { default: sharp } = await import('sharp')
   const img = sharp(buffer)
   const { width, height } = await img.metadata()
   if (width == null || height == null) return
   const aspectRatio = width / height
-  const blurWidth = 8
-  const blurHeight = Math.max(1, Math.round(blurWidth / aspectRatio))
-  const blurImage = await img.resize(blurWidth, blurHeight).webp({ quality: 1 }).toBuffer()
+  const blurWidth = blurOptions.width ?? 8
+  const blurHeight = blurOptions.height ?? Math.max(1, Math.round(blurWidth / aspectRatio))
+  const quality = blurOptions.quality ?? 1
+  const blurImage = await img.resize(blurWidth, blurHeight).webp({ quality }).toBuffer()
   const blurDataURL = `data:image/webp;base64,${blurImage.toString('base64')}`
   return { height, width, blurDataURL, blurWidth, blurHeight }
 }
@@ -83,6 +105,7 @@ export const getImageMetadata = async (buffer: Buffer): Promise<Omit<Image, 'src
  * @param filename output filename template
  * @param baseUrl output public base url
  * @param isImage process as image and return image object with blurDataURL
+ * @param blurOptions blur placeholder options (only used when isImage is true)
  * @returns reference public url or image object
  */
 export const processAsset = async <T extends true | undefined = undefined>(
@@ -90,7 +113,8 @@ export const processAsset = async <T extends true | undefined = undefined>(
   from: string,
   filename: string,
   baseUrl: string,
-  isImage?: T
+  isImage?: T,
+  blurOptions?: BlurOptions
 ): Promise<T extends true ? Image : string> => {
   // e.g. input = '../assets/image.png?foo=bar#hash'
   const queryIdx = input.indexOf('?')
@@ -125,7 +149,7 @@ export const processAsset = async <T extends true | undefined = undefined>(
 
   if (isImage !== true) return src as T extends true ? Image : string
 
-  const metadata = await getImageMetadata(buffer)
+  const metadata = await getImageMetadata(buffer, blurOptions)
   if (metadata == null) throw new Error(`invalid image: ${from}`)
   return { src, ...metadata } as T extends true ? Image : string
 }

--- a/src/schemas/image.ts
+++ b/src/schemas/image.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 import { getImageMetadata, processAsset } from '../assets'
 import { string } from './zod'
 
-import type { Image } from '../assets'
+import type { BlurOptions, Image } from '../assets'
 
 export interface ImageOptions {
   /**
@@ -12,6 +12,11 @@ export interface ImageOptions {
    * @default undefined
    */
   absoluteRoot?: string
+  /**
+   * blur placeholder options (width / height / quality)
+   * @default undefined
+   */
+  blur?: BlurOptions
   // /**
   //  * allow remote url
   //  * @default false
@@ -22,12 +27,12 @@ export interface ImageOptions {
 /**
  * Image schema
  */
-export const image = ({ absoluteRoot }: ImageOptions = {}) =>
+export const image = ({ absoluteRoot, blur }: ImageOptions = {}) =>
   string().transform<Image>(async (value, { meta, addIssue }) => {
     try {
       if (absoluteRoot && /^\//.test(value)) {
         const buffer = await readFile(join(absoluteRoot, value))
-        const metadata = await getImageMetadata(buffer)
+        const metadata = await getImageMetadata(buffer, blur)
         if (metadata == null) throw new Error(`Failed to get image metadata: ${value}`)
         return { src: value, ...metadata }
       }
@@ -44,7 +49,7 @@ export const image = ({ absoluteRoot }: ImageOptions = {}) =>
 
       const { output } = meta.config
       // process asset as relative path
-      return await processAsset(value, meta.path, output.name, output.base, true)
+      return await processAsset(value, meta.path, output.name, output.base, true, blur)
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       addIssue({ fatal: true, code: 'custom', message })

--- a/test/assets.ts
+++ b/test/assets.ts
@@ -1,0 +1,42 @@
+import { strictEqual } from 'node:assert'
+import { readFile } from 'node:fs/promises'
+import { describe, it } from 'node:test'
+
+import { getImageMetadata } from '../src/assets'
+
+// path relative to cwd (repo root), like the other tests
+const image = 'examples/basic/content/posts/2024-05-08-hello-world/cover.jpg'
+
+describe('getImageMetadata function', async () => {
+  it('generates blur placeholder with default options', async () => {
+    const buffer = await readFile(image)
+    const metadata = await getImageMetadata(buffer)
+    strictEqual(metadata != null, true)
+    strictEqual(metadata!.blurWidth, 8)
+    // blurHeight is derived from the aspect ratio and is at least 1
+    strictEqual(metadata!.blurHeight >= 1, true)
+    strictEqual(metadata!.blurDataURL.startsWith('data:image/webp;base64,'), true)
+  })
+
+  it('respects custom blur width and derives height from aspect ratio', async () => {
+    const buffer = await readFile(image)
+    const metadata = await getImageMetadata(buffer, { width: 16 })
+    strictEqual(metadata!.blurWidth, 16)
+    const aspectRatio = metadata!.width / metadata!.height
+    strictEqual(metadata!.blurHeight, Math.max(1, Math.round(16 / aspectRatio)))
+  })
+
+  it('respects explicit blur width and height', async () => {
+    const buffer = await readFile(image)
+    const metadata = await getImageMetadata(buffer, { width: 20, height: 20 })
+    strictEqual(metadata!.blurWidth, 20)
+    strictEqual(metadata!.blurHeight, 20)
+  })
+
+  it('produces a larger data url with higher blur quality', async () => {
+    const buffer = await readFile(image)
+    const low = await getImageMetadata(buffer, { quality: 1 })
+    const high = await getImageMetadata(buffer, { quality: 80 })
+    strictEqual(high!.blurDataURL.length > low!.blurDataURL.length, true)
+  })
+})


### PR DESCRIPTION
Allow customizing the generated blurDataURL placeholder via a `blur` option ({ width, height, quality }) on `s.image()`. The option threads through `processAsset` into `getImageMetadata`. Defaults reproduce the previous behavior (width 8, height from aspect ratio, quality 1).

Closes #382